### PR TITLE
Validate input type - fixes #1 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 'use strict';
 module.exports = year => {
 	year = year || new Date();
+
+	if (!(year instanceof Date) && typeof year !== 'number') {
+		throw new TypeError(`Expected \`year\` to be of type \`Date\` or \`number\`, got \`${typeof year}\``);
+	}
+
 	year = year instanceof Date ? year.getFullYear() : year;
 	return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 };

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import m from './';
 
 test(t => {
+	t.throws(() => m('foo'), 'Expected `year` to be of type `Date` or `number`, got `string`');
 	t.is(typeof m(), 'boolean');
 	t.false(m(2014));
 	t.true(m(2016));

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import m from './';
 
 test(t => {
-	t.throws(() => m('foo'), 'Expected `year` to be of type `Date` or `number`, got `string`');
+	t.throws(() => m('foo'), TypeError);
 	t.is(typeof m(), 'boolean');
 	t.false(m(2014));
 	t.true(m(2016));


### PR DESCRIPTION
Check the input type and throw a `TypeError` if it's not a `Date` or a `number`.